### PR TITLE
Replaced the prims-Steiner tree code with networkx's steiner_tree

### DIFF
--- a/pauliopt/topologies.py
+++ b/pauliopt/topologies.py
@@ -316,6 +316,21 @@ class Topology:
                 path.append(fro)
             return path
 
+    def steiner_tree(self, terminals: list[int], exclude: list[int]=[]):
+        """
+            Computes the Steiner tree over the topology with given terminals.
+            `exclude` can be used to find the Steiner tree of a subgraph of the topology where the given nodes are excluded.
+            Requires networkx to be installed to work.
+            Returns a networkx Graph.
+        """
+        try:
+            # pylint: disable = import-outside-toplevel
+            from networkx.algorithms.approximation.steinertree import steiner_tree
+        except ModuleNotFoundError as _:
+            raise ModuleNotFoundError("You must install the 'networkx' library.")
+        nodes = [n for n in self.qubits if n not in exclude]
+        G = self.to_nx.subgraph(nodes)
+        return steiner_tree(G, terminals)
 
     def mapped_bwd(self, mapping: Union[Sequence[int], Dict[int, int]]) -> "Topology":
         """


### PR DESCRIPTION
Fix for issue #3 
Replaced the Steiner-tree code with the built-in from networkx.
The Steiner-tree is built in the Topology class, rather than in a global function in `phase_circuits.py`, which would make it more accessible for when issue #12 is implemented.
There is now also only a single function, rather than 3 to build the tree. The weight can be obtained from the Graph and the branches should not have existed in the first place, since they caused the issue.

The old issue still persists in the PauliGadget class, but I think it's better for the PauliGadgets to be turned into a PhaseGadget and then use the code from there in stead of recreating the PhaseGadget code in the PauliGadget class. But I also expect that that should maybe be a different issue.