### PR TITLE
Add circuit class

### DIFF
--- a/pauliopt/circuits.py
+++ b/pauliopt/circuits.py
@@ -1,0 +1,126 @@
+"""
+A general class for quantum circuits, with a ZX / Gadget representation.
+"""
+
+from math import ceil, log10
+from typing import List
+
+import numpy as np
+
+from pauliopt.utils import SVGBuilder
+from pauliopt.gates import Gate
+
+
+class Circuit:
+    """ Class for representing quantum circuits. """
+    def __init__(self, n_qubits, _gates=None):
+        self.n_qubits = n_qubits
+        self._gates = [] if _gates is None else _gates
+
+        for gate in self._gates:
+            self._check_gate(gate)
+
+    def add_gate(self, gate):
+        return self.add_gates([gate])
+
+    def add_gates(self, gates):
+        for gate in gates:
+            self._check_gate(gate)
+        self._gates.extend(gates)
+        return self
+
+    def to_phase_circuit(self):
+        from pauliopt.phase import Circuit as PhaseCircuit
+        gadgets = [g for gate in self._gates for g in gate.gadgets]
+        return PhaseCircuit(self.n_qubits, gadgets)
+
+    def _check_gate(self, gate):
+        n_qubits = self.n_qubits
+        for gate in self._gates:
+            if not isinstance(gate, Gate):
+                raise TypeError(f"{gate} is not a valid gate.")
+            if len(set(gate.qubits)) != len(gate.qubits):
+                raise ValueError(f"{gate.qubits} are not unique.")
+            if any(not (0 <= qubit < n_qubits) for qubit in gate.qubits):
+                msg = f"{gate} acts out of range for {n_qubits} qubit circuit."
+                raise ValueError(msg)
+
+    def __repr__(self) -> str:
+        return f"Circuit({self.n_qubits}, {self._gates})"
+
+    def _to_svg(self, *,
+                zcolor: str = "#CCFFCC",
+                xcolor: str = "#FF8888",
+                hcolor: str = "#FFFF00",
+                hscale: float = 1.0, vscale: float = 1.0,
+                scale: float = 1.0,
+                svg_code_only: bool = False
+                ):
+        # pylint: disable = too-many-locals, too-many-statements, too-many-branches
+        num_qubits = self.n_qubits
+        vscale *= scale
+        hscale *= scale
+
+        gates = list(self._gates)
+        _layers: List[int] = [0] * num_qubits
+        row_widths = [0] * len(gates)
+        ds = []
+        max_gates_depth: int = 0
+        for gate in gates:
+            m = min(gate.qubits)
+            M = max(gate.qubits)
+            d = max(_layers[q] for q in range(m, M+1))
+            ds.append(d)
+            max_gates_depth = max(max_gates_depth, d+1)
+            for q in range(m, M+1):
+                _layers[q] = d+1
+
+            gate_width = getattr(gate, 'width', int(ceil(40*hscale)))
+            row_widths[d] = max(row_widths[d], gate_width)
+        num_digits = int(ceil(log10(num_qubits)))
+        line_height = int(ceil(30*vscale))
+        pad_x = int(ceil(10*hscale))
+        pad_y = int(ceil(20*vscale))
+        r = 6
+        total_gate_width = sum(row_widths)
+        font_size = 2*r
+        pad_x += font_size*(num_digits+1)
+        width = total_gate_width
+        height = pad_y + line_height*(num_qubits+1)
+        builder = SVGBuilder(width, height)
+        row_pos = np.cumsum([pad_x] + row_widths).tolist()
+
+        params = {
+            'text_off': (10 * hscale, -10 * vscale),
+            'zcolor': zcolor,
+            'xcolor': xcolor,
+            'hcolor': hcolor,
+            'line_height': line_height,
+            'font_size': font_size,
+            'r': r,
+        }
+
+        # draw gate
+        for d, gate in zip(ds, gates):
+            base = row_pos[d], pad_y
+            gate.draw(builder, base, row_widths[d], params)
+
+        # label wires
+        width = pad_x + total_gate_width + pad_x
+        _builder = SVGBuilder(width, height)
+        for q in range(num_qubits):
+            y = pad_y + (q+1) * line_height
+            txt = f"{str(q):>{num_digits}}"
+            _builder.line((pad_x, y), (width-pad_x, y))
+            _builder.text((0, y), txt, font_size=font_size)
+            _builder.text((width-pad_x+r, y), txt, font_size=font_size)
+        _builder >>= builder
+        svg_code = repr(_builder)
+        if svg_code_only:
+            return svg_code
+        try:
+            # pylint: disable = import-outside-toplevel
+            from IPython.core.display import SVG  # type: ignore
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError("You must install the 'IPython' library.")
+        return SVG(svg_code)

--- a/pauliopt/gates.py
+++ b/pauliopt/gates.py
@@ -1,0 +1,391 @@
+from abc import ABC
+from itertools import combinations
+from math import ceil
+
+from pauliopt.phase import pi
+from pauliopt.phase import Z as ZHead
+from pauliopt.phase import X as XHead
+from pauliopt.phase.phase_circuits import PhaseGadget
+
+
+class Gate(ABC):
+    """ Base class for quantum gates. """
+    def __init__(self, *qubits):
+        self.qubits = qubits
+        self.name = self.__class__.__name__
+        if len(qubits) != self.n_qubits:
+            name, n_qubits = self.name, self.n_qubits
+            raise ValueError(f"{name} takes {n_qubits} qubits, not {len(qubits)}.")
+
+    def __repr__(self) -> str:
+        args = map(repr, self.qubits)
+        return f"{self.name}({', '.join(args)})"
+
+    @property
+    def width(self):
+        """ Width of gate used for drawing. """
+        if getattr(self, 'draw_as_zx', False):
+            n_columns = max(self._gen_columns())
+            return n_columns * 20 + 40
+
+        vscale = 1.0
+        line_height = int(ceil(30*vscale))
+        min_qubit = min(self.qubits)
+        max_qubit = max(self.qubits)
+        text = repr(self)
+        box_height = max(30, (max_qubit - min_qubit) * line_height + 10)
+        box_width = max(8 * len(text), box_height * 1.5)
+        return int(box_width)
+
+    def _gen_columns(self):
+        n_columns = 0
+        gate_cls = None
+        # shift by 3 columns if a multi-legged gadget was drawn
+        big_gadget_drawn = False
+        for g in self.decomp:
+            if gate_cls != (type(g), getattr(g, 'basis', None)):
+                gate_cls = (type(g), getattr(g, 'basis', None))
+                n_columns += 3 if big_gadget_drawn else 1
+                big_gadget_drawn = False
+            if isinstance(g, PhaseGadget) and len(g.qubits) > 1:
+                big_gadget_drawn = True
+            yield n_columns
+        n_columns += 3 if big_gadget_drawn else 1
+        big_gadget_drawn = False
+        yield n_columns
+
+    def draw_zx(self, builder, base, row_width, params):
+        n_columns = max(self._gen_columns())
+        step = row_width / n_columns
+
+        busy = set()
+        for g, column_idx in zip(self.decomp, self._gen_columns()):
+            x, y = base[0] + column_idx * step, base[1]
+
+            if len(g.qubits) > 1:
+                # gadget body blocks text
+                busy.add(min(g.qubits) + 1)
+            text_above = True
+            if len(g.qubits) == 1 and tuple(g.qubits)[0] in busy:
+                text_above = False
+            if isinstance(g, PhaseGadget):
+                draw_gadget(builder, (x, y), row_width, params, g, text_above)
+            else:
+                g.draw(builder, base, row_width, params)
+
+    def draw_box(self, builder, base, row_width, params):
+        line_height = params['line_height']
+        font_size = params['font_size']
+
+        min_qubit = min(self.qubits)
+        max_qubit = max(self.qubits)
+        x = base[0] + row_width / 2
+        y = base[1] + ((min_qubit + max_qubit) / 2 + 1) * line_height
+        text = repr(self)
+        box_height = max(30, (max_qubit - min_qubit) * line_height + 10)
+        box_width = max(8 * len(text), box_height * 1.5)
+
+        builder.rect((x, y), box_width, box_height, '#FFFFFF')
+        builder.text((x, y), text, font_size=font_size, center=True)
+
+    def draw(self, builder, base, row_width, params):
+        # builder.line((base[0], 0), (base[0], 100))
+        # builder.line((base[0] + row_width, 0), (base[0] + row_width, 100))
+        if getattr(self, 'draw_as_zx', False):
+            self.draw_zx(builder, base, row_width, params)
+        else:
+            self.draw_box(builder, base, row_width, params)
+
+    @property
+    def gadgets(self):
+        """ List of gadgets used to implement this gate. """
+        if not hasattr(self, 'decomp'):
+            raise NotImplementedError
+
+        gadgets = [
+            g if isinstance(g, (ZHead, XHead)) else g.gadgets
+            for g in self.decomp
+        ]
+        return gadgets
+
+
+class PhaseGate(Gate):
+    def __init__(self, phase, *qubits):
+        super().__init__(*qubits)
+        self.phase = phase
+
+    def __repr__(self) -> str:
+        args = map(repr, self.qubits)
+        return f"{self.name}({self.phase}, {', '.join(args)})"
+
+
+class H(Gate):
+    n_qubits = 1
+    width = 40
+
+    @property
+    def decomp(self):
+        p = pi / 2
+        q, = self.qubits
+        return [ZHead(p) @ {q}, XHead(p) @ {q}, ZHead(p) @ {q}]
+
+    def draw(self, builder, base, row_width, params):
+        line_height = params['line_height']
+        r = params['r']
+        hcolor = params['hcolor']
+        qubit = self.qubits[0]
+        x = base[0] + row_width / 2
+        y = base[1] + (qubit+1)*line_height
+        builder.rect((x, y), 1.5*r, 1.5*r, hcolor)
+
+
+class X(Gate):
+    n_qubits = 1
+    draw_as_zx = True
+
+    @property
+    def decomp(self):
+        return [XHead(pi) @ {self.qubits[0]}]
+
+
+class Z(Gate):
+    n_qubits = 1
+    draw_as_zx = True
+
+    @property
+    def decomp(self):
+        return [ZHead(pi) @ {self.qubits[0]}]
+
+
+class Y(Gate):
+    n_qubits = 1
+    draw_as_zx = True
+
+    @property
+    def decomp(self):
+        # TODO check this
+        return [ZHead(pi) @ {self.qubits[0]}, XHead(pi) @ {self.qubits[0]}]
+
+
+class S(Gate):
+    n_qubits = 1
+    draw_as_zx = True
+
+    @property
+    def decomp(self):
+        return [ZHead(pi / 2) @ {self.qubits[0]}]
+
+
+class T(Gate):
+    n_qubits = 1
+    draw_as_zx = True
+
+    @property
+    def decomp(self):
+        return [ZHead(pi / 4) @ {self.qubits[0]}]
+
+
+class SWAP(Gate):
+    n_qubits = 2
+    draw_as_zx = True
+
+    @property
+    def decomp(self):
+        q0, q1 = self.qubits
+        return [CX(q0, q1), CX(q1, q0), CX(q0, q1)]
+
+
+class CX(Gate):
+    n_qubits = 2
+    draw_as_zx = True
+    width = 40
+
+    @property
+    def decomp(self):
+        q0, q1 = self.qubits
+        return [H(q1), CZ(q0, q1), H(q1)]
+
+    def draw(self, builder, base, row_width, params):
+        r = params['r']
+        line_height = params['line_height']
+        zcolor = params['zcolor']
+        xcolor = params['xcolor']
+
+        ctrl, trgt = self.qubits
+        x = base[0] + row_width / 2
+        y_ctrl = base[1] + (ctrl+1)*line_height
+        y_trgt = base[1] + (trgt+1)*line_height
+        builder.line((x, y_ctrl), (x, y_trgt))
+        builder.circle((x, y_ctrl), r, zcolor)
+        builder.circle((x, y_trgt), r, xcolor)
+
+
+class CY(Gate):
+    n_qubits = 2
+    draw_as_zx = True
+
+    @property
+    def decomp(self):
+        q0, q1 = self.qubits
+        return [XHead(pi/2) @ {q1}, CZ(q0, q1), XHead(-pi/2) @ {q1}]
+
+
+class CZ(Gate):
+    n_qubits = 2
+    draw_as_zx = True
+
+    @property
+    def decomp(self):
+        q0, q1 = self.qubits
+        return [ZHead(pi/2) @ {q0, q1}]
+
+    def draw(self, builder, base, row_width, params):
+        r = params['r']
+        line_height = params['line_height']
+        zcolor = params['zcolor']
+        hcolor = params['hcolor']
+
+        ctrl, trgt = self.qubits
+        x = base[0] + row_width / 2
+        y_ctrl = base[1] + (ctrl+1)*line_height
+        y_trgt = base[1] + (trgt+1)*line_height
+        y_mid = (y_ctrl + y_trgt) / 2
+        builder.line((x, y_ctrl), (x, y_trgt))
+        builder.circle((x, y_ctrl), r, zcolor)
+        builder.circle((x, y_trgt), r, zcolor)
+        builder.rect((x, y_mid), r, r, hcolor)
+
+
+class CCX(Gate):
+    n_qubits = 3
+    draw_as_zx = True
+
+    @property
+    def decomp(self):
+        q0, q1, q2 = self.qubits
+        return [H(q2), CCZ(q0, q1, q2), H(q2)]
+
+
+class CCZ(Gate):
+    n_qubits = 3
+    draw_as_zx = True
+
+    @property
+    def decomp(self):
+        gs = []
+
+        for i in range(1, self.n_qubits + 1):
+            for qs in combinations(self.qubits, i):
+                gs.append(ZHead(-1 ** len(qs) * pi/2) @ set(qs))
+        return gs
+
+
+class Rx(PhaseGate):
+    n_qubits = 1
+    draw_as_zx = True
+
+    @property
+    def decomp(self):
+        q, = self.qubits
+        return [XHead(self.phase) @ {q}]
+
+
+class Ry(PhaseGate):
+    n_qubits = 1
+    draw_as_zx = True
+
+    @property
+    def decomp(self):
+        q, = self.qubits
+        return [XHead(pi/2) @ {q}, ZHead(self.phase) @ {q}, XHead(-pi/2) @ {q}]
+
+
+class Rz(PhaseGate):
+    n_qubits = 1
+    draw_as_zx = True
+
+    @property
+    def decomp(self):
+        q, = self.qubits
+        return [ZHead(self.phase) @ {q}]
+
+
+class CRx(PhaseGate):
+    n_qubits = 2
+    draw_gadget = True
+
+    @property
+    def decomp(self):
+        p = self.phase
+        q0, q1 = self.qubits
+        return [H(q1), CRz(p, q0, q1), H(q1)]
+
+
+class CRy(PhaseGate):
+    n_qubits = 2
+    draw_gadget = True
+
+    @property
+    def decomp(self):
+        p = self.phase
+        q0, q1 = self.qubits
+        return [XHead(pi/2, q1), CRz(p, q0, q1), XHead(-pi/2, q1)]
+
+
+class CRz(PhaseGate):
+    n_qubits = 2
+    draw_as_zx = True
+
+    @property
+    def decomp(self):
+        p = self.phase
+        q0, q1 = self.qubits
+        return [ZHead(-p/2) @ {q0, q1}, ZHead(p/2) @ {q1}]
+
+
+CNOT = CX
+
+
+def draw_gadget(builder, base, row_width, params, gadget, text_above=True):
+    line_height = params['line_height']
+    text_off_x, text_off_y = params['text_off']
+    font_size = params['font_size']
+    r = params['r']
+
+    if gadget.basis == 'Z':
+        color1, color2 = params['zcolor'], params['xcolor']
+    elif gadget.basis == 'X':
+        color1, color2 = params['xcolor'], params['zcolor']
+    else:
+        raise ValueError
+
+    step = row_width / 4
+    body = min(gadget.qubits) + 0.5
+    x = base[0]
+    x_body = x + step
+    y_body = base[1] + (body+1) * line_height
+
+    if len(gadget.qubits) > 1:
+        for q in gadget.qubits:
+            y = base[1] + (q+1)*line_height
+            builder.line((x, y), (x_body, y_body))
+            builder.circle((x, y), r, color1)
+        builder.line((x_body, y_body), (x_body + step, y_body))
+        builder.circle((x_body, y_body), r, color2)
+        builder.circle((x_body + step, y_body), r, color1)
+
+        text_x = x_body + step + text_off_x
+        text_y = y_body
+    else:
+        assert len(gadget.qubits) == 1
+        q = tuple(gadget.qubits)[0]
+        y = base[1] + (q+1)*line_height
+        builder.circle((x, y), r, color1)
+
+        text_x = x + text_off_x
+        if text_above:
+            text_y = y + text_off_y
+        else:
+            text_y = y - text_off_y
+
+    builder.text((text_x, text_y), str(gadget.angle), font_size=font_size)

--- a/pauliopt/utils.py
+++ b/pauliopt/utils.py
@@ -579,8 +579,8 @@ class AngleVar(AngleExpr):
 def _validate_vec2(vec2: Tuple[int, int]) -> None:
     if not isinstance(vec2, tuple) or len(vec2) != 2:
         raise TypeError("Expected pair.")
-    if not all(isinstance(x, int) for x in vec2):
-        raise TypeError("Expected pair of integers.")
+    if not all(isinstance(x, (int, float)) for x in vec2):
+        raise TypeError("Expected pair of integers or floats.")
 
 class SVGBuilder:
     """
@@ -666,7 +666,21 @@ class SVGBuilder:
         self._tags.append(tag)
         return self
 
-    def text(self, pos: Tuple[int, int], text: str, *, font_size: int = 10) -> "SVGBuilder":
+    def rect(self, centre: Tuple[int, int], width: int, height: int, fill: str) -> "SVGBuilder":
+        """
+            Draws a rectangle with given centre, width and height.
+        """
+        _validate_vec2(centre)
+        if not isinstance(fill, str):
+            raise TypeError("Fill must be string.")
+        x, y = centre
+        tag = (f'<rect fill="{fill}" stroke="black"'
+               f' x="{x-width//2}" y="{y-height//2}"'
+               f' width="{width}" height="{height}"/>')
+        self._tags.append(tag)
+        return self
+
+    def text(self, pos: Tuple[int, int], text: str, *, font_size: int = 10, center=False) -> "SVGBuilder":
         """
             Draws text at the given position (stroke/fill not used).
         """
@@ -676,7 +690,9 @@ class SVGBuilder:
         if not isinstance(font_size, int) or font_size <= 0:
             raise TypeError("Font size must be positive integer.")
         x, y = pos
-        tag = f'<text x="{x}" y="{y+font_size//4}" font-size="{font_size}">{text}</text>'
+        attrs =  f'x="{x}" y="{y+font_size//4}" font-size="{font_size}"'
+        attrs += f' text-anchor="middle"' if center else ""
+        tag = f'<text {attrs}>{text}</text>'
         self._tags.append(tag)
         return self
 


### PR DESCRIPTION
In pauliopt, currently we can represent quantum computational either as a list of phase gadgets or a list of pauli gadgets.
1. In some scenarios compilation may benefit from the structural information that is lost when converting to gadgets.
2. Users may want to specify their problem in circuit form (more user friendly)
3. Better interoperability between other circuit libraries

This PR adds a circuit representation where each gate is described as a list of Cliffords and gadgets, along with a circuit drawing function and phase gadget conversion based on this description.

![image](https://github.com/sg495/pauliopt/assets/13847804/a2d0f7fa-7624-4955-90a2-42d18bee62ae)
